### PR TITLE
Feat: 로또 티켓 구매 및 GameManager 연동 로직 구현

### DIFF
--- a/Assets/Scenes/Lotto/LottoScene.unity
+++ b/Assets/Scenes/Lotto/LottoScene.unity
@@ -1173,7 +1173,7 @@ GameObject:
   - component: {fileID: 417730567}
   - component: {fileID: 417730566}
   m_Layer: 5
-  m_Name: ' PlaysLeftText'
+  m_Name: PlaysLeftText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2935,6 +2935,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 905326363}
   m_CullTransparentMesh: 1
+--- !u!1 &984907878
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 984907879}
+  - component: {fileID: 984907881}
+  - component: {fileID: 984907880}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &984907879
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984907878}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1315833378}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &984907880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984907878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Buy/Show result
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &984907881
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984907878}
+  m_CullTransparentMesh: 1
 --- !u!1 &1036721807
 GameObject:
   m_ObjectHideFlags: 0
@@ -2967,7 +3103,8 @@ RectTransform:
   m_Children:
   - {fileID: 1096163737}
   - {fileID: 1860976735}
-  - {fileID: 1336389813}
+  - {fileID: 2059920297}
+  - {fileID: 1315833378}
   m_Father: {fileID: 404998343}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3321,10 +3458,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1036721808}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0054779, y: 62.6097}
-  m_SizeDelta: {x: 1489.1, y: 44.3309}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 644.22, y: 2.9412}
+  m_SizeDelta: {x: 1189.8475, y: 55.8825}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1096163738
 MonoBehaviour:
@@ -3778,7 +3915,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1177795361}
   m_CullTransparentMesh: 1
---- !u!1 &1336389812
+--- !u!1 &1315833377
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3786,9 +3923,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1336389813}
-  - component: {fileID: 1336389815}
-  - component: {fileID: 1336389814}
+  - component: {fileID: 1315833378}
+  - component: {fileID: 1315833380}
+  - component: {fileID: 1315833379}
+  - component: {fileID: 1315833381}
   m_Layer: 5
   m_Name: PlayButton
   m_TagString: Untagged
@@ -3796,37 +3934,38 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1336389813
+--- !u!224 &1315833378
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1336389812}
+  m_GameObject: {fileID: 1315833377}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 984907879}
   m_Father: {fileID: 1036721808}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -187.653, y: 28.739}
-  m_SizeDelta: {x: 322.2493, y: 57.479}
+  m_AnchoredPosition: {x: -174.594, y: 46.64898}
+  m_SizeDelta: {x: 316.3768, y: 56.702}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1336389814
+--- !u!114 &1315833379
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1336389812}
+  m_GameObject: {fileID: 1315833377}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3835,85 +3974,80 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Buy/Show result
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 4
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0.000061035156, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1336389815
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1315833380
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1336389812}
+  m_GameObject: {fileID: 1315833377}
   m_CullTransparentMesh: 1
+--- !u!114 &1315833381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315833377}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1315833379}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1935718420}
+        m_TargetAssemblyTypeName: LottoManager, Assembly-CSharp
+        m_MethodName: OnClickPlay
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &1378409895
 GameObject:
   m_ObjectHideFlags: 0
@@ -5808,10 +5942,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1036721808}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0029452, y: -8.7607}
-  m_SizeDelta: {x: 1489.1, y: 67.5215}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 769, y: 41.239}
+  m_SizeDelta: {x: 1439.4, y: 67.522}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1860976736
 MonoBehaviour:
@@ -5833,7 +5967,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Result
+  m_text: 'Result: '
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -5898,7 +6032,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_margin: {x: -3.3471684, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -6077,8 +6211,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b14c2500802994c3aa85a04d228cf01e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::LottoManager
+  ticketPrice: 10000
   numbersToChoose: 4
+  moneyText: {fileID: 489823714}
+  playsLeftText: {fileID: 417730566}
+  ticketPriceText: {fileID: 2059920298}
   selectedNumbersText: {fileID: 1096163738}
+  resultText: {fileID: 1860976736}
+  playButton: {fileID: 1315833381}
   numberButtons:
   - {fileID: 837409783}
   - {fileID: 294849511}
@@ -6472,6 +6612,142 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2051593542}
+  m_CullTransparentMesh: 1
+--- !u!1 &2059920296
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2059920297}
+  - component: {fileID: 2059920299}
+  - component: {fileID: 2059920298}
+  m_Layer: 5
+  m_Name: TicketPriceText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2059920297
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2059920296}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1036721808}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -325.84332, y: 0}
+  m_SizeDelta: {x: 113.0622, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2059920298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2059920296}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Ticket price: 10000'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -248.43875, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2059920299
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2059920296}
   m_CullTransparentMesh: 1
 --- !u!1 &2073527756
 GameObject:

--- a/Assets/Scripts/Common/GameData.cs
+++ b/Assets/Scripts/Common/GameData.cs
@@ -35,4 +35,15 @@ public class GameData
     {
         Money += amount;
     }
+
+    public bool UsePlay()
+    {
+        if (PlaysLeft <= 0)
+        {
+            return false;
+        }
+
+        PlaysLeft--;
+        return true;
+    }
 }

--- a/Assets/Scripts/Common/GameManager.cs
+++ b/Assets/Scripts/Common/GameManager.cs
@@ -66,4 +66,14 @@ public class GameManager : MonoBehaviour
         Data.AddMoney(amount);
         NotifyStateChanged();
     }
+
+    public bool TryUsePlay()
+    {
+        bool result = Data.UsePlay();
+        if (result)
+        {
+            NotifyStateChanged();
+        }
+        return result;
+    }
 }

--- a/Assets/Scripts/Lotto/Managers/LottoManager.cs
+++ b/Assets/Scripts/Lotto/Managers/LottoManager.cs
@@ -2,23 +2,50 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using TMPro;
+using UnityEngine.UI;
 
 public class LottoManager : MonoBehaviour
 {
     [Header("설정값")]
+    public int ticketPrice = 10000;
     public int numbersToChoose = 4;
 
     [Header("UI")]
+    public TextMeshProUGUI moneyText;
+    public TextMeshProUGUI playsLeftText;
+    public TextMeshProUGUI ticketPriceText;
     public TextMeshProUGUI selectedNumbersText;
+    public TextMeshProUGUI resultText;
+    public Button playButton;
 
     [Header("번호 버튼들")]
     public List<LottoNumberButton> numberButtons;
 
-    private List<int> selectedNumbers = new List<int>();
+    private readonly List<int> selectedNumbers = new List<int>();
+
+    private void OnEnable()
+    {
+        // GameManager 상태 변경 이벤트 구독
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStateChanged += RefreshTopUI;
+        }
+
+        // 씬에 처음 들어올 때도 한 번 갱신
+        RefreshTopUI();
+    }
+
+    private void OnDisable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnGameStateChanged -= RefreshTopUI;
+        }
+    }
 
     private void Start()
     {
-        // 버튼들에 매니저 연결 & 초기화
+        // 번호 버튼 초기화
         foreach (var btn in numberButtons)
         {
             if (btn == null) continue;
@@ -26,7 +53,53 @@ public class LottoManager : MonoBehaviour
             btn.SetSelected(false);
         }
 
+        RefreshTicketUI(); // 티켓 가격 표시
         RefreshSelectedNumbersText();
+
+        if (resultText != null) resultText.text = "";
+
+        // 처음에는 번호 4개 선택 전이니까 버튼은 일단 비활성화해도 됨
+        UpdatePlayButtonInteractable();
+    }
+
+    private void RefreshTopUI()
+    {
+        if (GameManager.Instance == null) return;
+
+        var data = GameManager.Instance.Data;
+        moneyText.text = $"Money {data.Money:N0}";
+        playsLeftText.text = $"{data.PlaysLeft} game left";
+    }
+
+    private void RefreshTicketUI()
+    {
+        if (ticketPriceText == null) return;
+        ticketPriceText.text = $"Ticket price: {ticketPrice:N0}";
+    }
+
+    private void RefreshSelectedNumbersText()
+    {
+        if (selectedNumbersText == null) return;
+
+        if (selectedNumbers.Count == 0)
+        {
+            selectedNumbersText.text = "Selected numbers: None";
+        }
+        else
+        {
+            selectedNumbersText.text =
+                "Selected numbers: " + string.Join(", ", selectedNumbers.OrderBy(x => x));
+        }
+
+        // 번호 선택 개수에 따라 플레이 버튼 활성/비활성
+        UpdatePlayButtonInteractable();
+    }
+
+    private void UpdatePlayButtonInteractable()
+    {
+        if (playButton == null) return;
+
+        playButton.interactable = (selectedNumbers.Count == numbersToChoose);
     }
 
     public void ToggleNumber(int number, LottoNumberButton button)
@@ -51,16 +124,51 @@ public class LottoManager : MonoBehaviour
         RefreshSelectedNumbersText();
     }
 
-    private void RefreshSelectedNumbersText()
+    public void OnClickPlay()
     {
-        if (selectedNumbers.Count == 0)
+        var gm = GameManager.Instance;
+        if (gm == null) return;
+
+        var data = gm.Data;
+
+        // 1. 번호 4개 다 골랐는지 체크
+        if (selectedNumbers.Count != numbersToChoose)
         {
-            selectedNumbersText.text = "Selected numbers: None";
+            resultText.text = $"You must select all {numbersToChoose} numbers.";
+            return;
         }
-        else
+
+        // 2) 오늘 남은 게임 수 체크
+        if (!gm.TryUsePlay())
         {
-            selectedNumbersText.text =
-                "Selected numbers: " + string.Join(", ", selectedNumbers.OrderBy(x => x));
+            if (resultText != null)
+                resultText.text = "You can't play any more games today.";
+            return;
         }
+
+        // 3) 티켓 가격만큼 돈 사용 시도
+        if (!gm.TrySpendMoney(ticketPrice))
+        {
+            if (resultText != null)
+                resultText.text = "You don't have enough money.";
+            return;
+        }
+
+        if (resultText != null)
+            resultText.text = "Ticket purchased. (Drawing logic will be implemented next)";
+            ClearSelection();
+    }
+
+    public void ClearSelection()
+    {
+        selectedNumbers.Clear();
+
+        foreach (var btn in numberButtons)
+        {
+            if (btn == null) continue;
+            btn.SetSelected(false);
+        }
+
+        RefreshSelectedNumbersText();
     }
 }


### PR DESCRIPTION
## 🧠 개요
LottoScene에서 티켓 구매 시 GameManager의 공통 상태(자산, 남은 플레이 횟수)를 활용하도록 연동하고,
UI와 버튼 활성화 상태가 이를 반영하도록 구현한다.

## ⚙️ 변경 내용
- GameData에 UsePlay() 추가, GameManager에 TryUsePlay() 래핑 메서드 추가
- LottoManager에서 GameManager.OnGameStateChanged 이벤트 구독/해제
  - OnEnable에서 RefreshTopUI 구독 및 초기 호출
  - OnDisable에서 구독 해제
- LottoManager UI 갱신 메서드 구현
  - RefreshTopUI: Money, PlaysLeft 텍스트 갱신
  - RefreshTicketUI: 티켓 가격 표시
  - RefreshSelectedNumbersText: 선택 번호 목록 갱신
  - UpdatePlayButtonInteractable: 선택 번호 개수에 따라 버튼 활성/비활성 처리
- OnClickPlay() 구현
  - 선택 번호 개수 검증 (numbersToChoose 개 선택 여부)
  - GameManager.TryUsePlay()로 오늘 남은 플레이 횟수 차감
  - GameManager.TrySpendMoney(ticketPrice)로 티켓 가격만큼 자산 차감
  - 조건 미충족 시 ResultText에 안내 메시지 표시
  - 구매 성공 시 티켓 구매 완료 메시지 출력

## 🔗 관련 이슈
closes #24 