### PR TITLE
Feat: 로또 추첨 및 등수·배당금 계산 로직 구현

### DIFF
--- a/Assets/Scenes/Lotto/LottoScene.unity
+++ b/Assets/Scenes/Lotto/LottoScene.unity
@@ -3105,6 +3105,7 @@ RectTransform:
   - {fileID: 1860976735}
   - {fileID: 2059920297}
   - {fileID: 1315833378}
+  - {fileID: 1364364075}
   m_Father: {fileID: 404998343}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3510,8 +3511,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40
-  m_fontSizeBase: 40
+  m_fontSize: 32
+  m_fontSizeBase: 32
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -4048,6 +4049,142 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &1364364074
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1364364075}
+  - component: {fileID: 1364364077}
+  - component: {fileID: 1364364076}
+  m_Layer: 5
+  m_Name: DrawResultText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1364364075
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1364364074}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1036721808}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 91.579895, y: 2.9414}
+  m_SizeDelta: {x: -1007.9114, y: 55.882}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1364364076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1364364074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Winning numbers will be shown here
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1364364077
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1364364074}
+  m_CullTransparentMesh: 1
 --- !u!1 &1378409895
 GameObject:
   m_ObjectHideFlags: 0
@@ -5944,8 +6081,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 769, y: 41.239}
-  m_SizeDelta: {x: 1439.4, y: 67.522}
+  m_AnchoredPosition: {x: 412.26, y: 48.325}
+  m_SizeDelta: {x: 725.9186, y: 53.351}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1860976736
 MonoBehaviour:
@@ -5994,8 +6131,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 32
+  m_fontSizeBase: 32
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -6032,7 +6169,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: -3.3471684, y: 0, z: 0, w: 0}
+  m_margin: {x: -3.3471684, y: 0, z: 10.769302, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -6213,12 +6350,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::LottoManager
   ticketPrice: 10000
   numbersToChoose: 4
+  minNumber: 1
+  maxNumber: 20
+  mainDrawCount: 5
   moneyText: {fileID: 489823714}
   playsLeftText: {fileID: 417730566}
   ticketPriceText: {fileID: 2059920298}
   selectedNumbersText: {fileID: 1096163738}
   resultText: {fileID: 1860976736}
   playButton: {fileID: 1315833381}
+  drawResultText: {fileID: 1364364076}
   numberButtons:
   - {fileID: 837409783}
   - {fileID: 294849511}


### PR DESCRIPTION
## 🧠 개요
LottoScene에서 티켓 구매 후 실제 로또 결과가 나오도록  
추첨 → 등수 판정 → 배당금 지급까지의 전체 흐름을 구현했습니다.

번호 선택 기능과 GameManager 상태 연동은 이전 단계에서 완료되어 있었고,  
이번 PR에서는 **실제 로또 로직**을 모두 연결하여 플레이가 가능한 상태를 만들었습니다.

## ⚙️ 변경 내용

### 1. 추첨 로직 구현
- 1~20 숫자 풀 생성
- 간단 셔플(Random.Range)로 무작위 순서 생성
- **앞 5개 = 메인 당첨 번호**
- **6번째 = 보너스 번호**
- UI에 표시하도록 drawResultText에 반영

### 2. 등수 계산 로직 구현
- 플레이어가 선택한 4개의 번호와 비교
- 일치 개수 + 보너스 유무로 등수 판정  
  - 1등: 메인 4개 일치 (30배)  
  - 2등: 메인 3개 + 보너스 (10배)  
  - 3등: 메인 3개 (5배)  
  - 4등: 메인 2개 (1배, 원금)  
  - 그 외: 꽝  
- 배당률은 rewardMultiplier 로 관리

### 3. 배당금 지급
- ticketPrice * rewardMultiplier 로 상금 계산
- 당첨 시 GameManager.Instance.AddMoney() 로 지급  
- GameManager의 OnGameStateChanged 이벤트를 통해  
  LottoScene 상단 Money UI 자동 업데이트

### 4. UI 출력
- drawResultText: 메인 5개 + 보너스 번호 표시
- resultText:  
  - 플레이어 선택 번호  
  - 등수  
  - 메인/보너스 일치 여부  
  - 지급된 배당금 표시

### 5. LottoManager 연동
- OnClickPlay() 내부에서 구매 조건 통과 후  
  PlayRoundAndResolveReward() 호출하도록 수정
- 구매 이후 버튼 활성/비활성 상태 갱신


## 🔗 관련 이슈
closes #28 