### PR TITLE
Feat: 로또 추첨 결과에 따른 번호 버튼 색상 강조 기능 구현

### DIFF
--- a/Assets/Scenes/Lotto/LottoScene.unity
+++ b/Assets/Scenes/Lotto/LottoScene.unity
@@ -175,6 +175,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &40966066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -451,6 +454,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &67153830
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -589,6 +595,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &116015725
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -727,6 +736,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &270917874
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -865,6 +877,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &294849512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1136,7 +1151,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0.8773585, g: 0.8773585, b: 0.8773585, a: 1}
+  m_Color: {r: 1, g: 0.9362603, b: 0.8537736, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1353,6 +1368,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &447155917
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1899,6 +1917,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &600684340
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2527,6 +2548,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!1 &856707510
 GameObject:
   m_ObjectHideFlags: 0
@@ -3126,7 +3150,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0.01886791, g: 0.01860091, b: 0.01860091, a: 0.8862745}
+  m_Color: {r: 0.4245283, g: 0.35444108, b: 0.35444108, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -3207,6 +3231,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1060149864
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3345,6 +3372,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1089818391
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3619,6 +3649,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1099996123
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3753,7 +3786,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.7529412}
+  m_Color: {r: 0.4866337, g: 0.5471698, b: 0.29681382, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -3834,6 +3867,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1177795364
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4378,6 +4414,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1408143528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4654,6 +4693,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1450478104
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5064,6 +5106,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1630162160
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5338,6 +5383,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1672988739
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5827,6 +5875,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1755385417
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5965,6 +6016,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &1769006407
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6593,7 +6647,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0.754717, g: 0.43075827, b: 0.43075827, a: 1}
+  m_Color: {r: 0.9245283, g: 0.5276789, b: 0.5276789, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -7082,6 +7136,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &2106388203
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7356,6 +7413,9 @@ MonoBehaviour:
   lottoManager: {fileID: 0}
   normalColor: {r: 1, g: 1, b: 1, a: 1}
   selectedColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  winColor: {r: 1, g: 0.9, b: 0.4, a: 1}
+  bonusColor: {r: 1, g: 0.5, b: 0.5, a: 1}
+  matchedColor: {r: 0.5, g: 1, b: 0.5, a: 1}
 --- !u!114 &2126689141
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Lotto/LottoNumberButton.cs
+++ b/Assets/Scripts/Lotto/LottoNumberButton.cs
@@ -9,6 +9,9 @@ public class LottoNumberButton : MonoBehaviour
     [Header("색상 설정")]
     public Color normalColor = Color.white;
     public Color selectedColor = new Color(0.8f, 0.8f, 0.8f);
+    public Color winColor = new Color(1f, 0.9f, 0.4f);    // 노란색
+    public Color bonusColor = new Color(1f, 0.5f, 0.5f);  // 붉은 색
+    public Color matchedColor = new Color(0.5f, 1f, 0.5f); // 녹색 
 
     private Button button;
     private bool isSelected = false;
@@ -48,4 +51,18 @@ public class LottoNumberButton : MonoBehaviour
     }
 
     public bool IsSelected() => isSelected;
+
+    public void SetHighlight(Color color)
+    {
+        var colors = button.colors;
+        colors.normalColor = color;
+        colors.highlightedColor = color;
+        colors.selectedColor = color;
+        button.colors = colors;
+    }
+
+    public void ResetColor()
+    {
+        SetHighlight(normalColor);
+    }
 }

--- a/Assets/Scripts/Lotto/Managers/LottoManager.cs
+++ b/Assets/Scripts/Lotto/Managers/LottoManager.cs
@@ -221,6 +221,8 @@ public class LottoManager : MonoBehaviour
         }
 
         //  8. UI에 당첨 번호 / 결과 표시
+        HighlightResultNumbers(mainNumbers, bonusNumber);
+
         if (drawResultText != null)
         {
             string mainStr = string.Join(", ", mainNumbers);
@@ -254,5 +256,42 @@ public class LottoManager : MonoBehaviour
         }
 
         RefreshSelectedNumbersText();
+    }
+
+    private void HighlightResultNumbers(List<int> mainNumbers, int bonusNumber)
+    {
+        foreach (var btn in numberButtons)
+        {
+            // 메인 당첨 번호
+            if (mainNumbers.Contains(btn.number))
+            {
+                // 내가 선택한 번호였고, 메인 번호와 일치하면 = 맞춘 번호!
+                if (selectedNumbers.Contains(btn.number))
+                {
+                    btn.SetHighlight(btn.matchedColor); // 초록색
+                }
+                else
+                {
+                    btn.SetHighlight(btn.winColor); // 노란색
+                }
+            }
+            // 보너스 번호
+            else if (btn.number == bonusNumber)
+            {
+                // 내가 선택했고 보너스 번호 맞춘 경우
+                if (selectedNumbers.Contains(btn.number))
+                {
+                    btn.SetHighlight(btn.matchedColor);  // 초록색
+                }
+                else
+                {
+                    btn.SetHighlight(btn.bonusColor); // 빨간색
+                }
+            }
+            else
+            {
+                btn.ResetColor();  // 일반 번호
+            }
+        }
     }
 }

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -58,7 +58,7 @@ GraphicsSettings:
   m_FogKeepExp2: 1
   m_AlbedoSwatchInfos: []
   m_RenderPipelineGlobalSettingsMap:
-    UnityEngine.Rendering.Universal.UniversalRenderPipeline: {fileID: 11400000, guid: 5d1da6ed4e5418c48a56d4de22aa618b, type: 2}
+    UnityEngine.Rendering.Universal.UniversalRenderPipeline: {fileID: 11400000, guid: 93b439a37f63240aca3dd4e01d978a9f, type: 2}
   m_LightsUseLinearIntensity: 1
   m_LightsUseColorTemperature: 1
   m_LogWhenShaderIsCompiled: 0


### PR DESCRIPTION
## 🧠 개요
로또 추첨 결과를 유저가 한눈에 이해할 수 있도록 번호 버튼에 당첨 여부에 따라 색상을 적용하는 기능 구현

- 메인 당첨 번호: 노란색
- 보너스 번호: 빨간색
- 플레이어가 맞춘 번호: 초록색
- 나머지 번호: 기본색

## ⚙️ 변경 내용
### 1. LottoNumberButton 색상 필드 추가
- normalColor, selectedColor, winColor(노랑), bonusColor(빨강), matchedColor(초록) 필드 추가

### 2. 번호 강조 관련 메서드 구현
- SetHighlight(Color color): 버튼을 특정 색상으로 강조하는 메서드 추가
- ResetColor(): 기본 색으로 초기화하는 메서드 추가

### 3. LottoManager에서 강조 처리 로직 추가
- HighlightResultNumbers(List<int> mainNumbers, int bonusNumber) 구현
- 로직 상세:
  - 메인 당첨 번호 → winColor
  - 보너스 번호 → bonusColor
  - 플레이어가 선택한 번호 중 당첨 번호 → matchedColor(초록)
  - 그 외 번호 → ResetColor()

### 4. 추첨 완료 시 강조 함수 호출
- PlayRoundAndResolveReward() 내부에서 HighlightResultNumbers(mainNumbers, bonusNumber) 호출

## 🔗 관련 이슈
closes #35 